### PR TITLE
fix(wrangler): updated wrangler compatibility flag to whole nodejs_compat

### DIFF
--- a/apps/server/wrangler.jsonc
+++ b/apps/server/wrangler.jsonc
@@ -3,6 +3,6 @@
   "main": "src/index.ts",
   "compatibility_date": "2025-02-14",
   "compatibility_flags": [
-    "nodejs_als"
+    "nodejs_compat"
   ]
 }


### PR DESCRIPTION
Whole `nodejs_compat` is needed for better auth

Related : https://github.com/better-auth/better-auth/issues/1375