### PR TITLE
feat(monitoring): configure PostHog client for immediate data processing

### DIFF
--- a/apps/server/src/modules/tracking/posthog.ts
+++ b/apps/server/src/modules/tracking/posthog.ts
@@ -38,6 +38,8 @@ export function createPostHogClient({
     {
       host,
       disableGeoip: true,
+      flushAt: 1,
+      flushInterval: 0,
     },
   );
 


### PR DESCRIPTION

> Note: When using PostHog in an AWS Lambda function or a similar serverless function environment, make sure you set flushAt to 1 and flushInterval to 0. Also, remember to always call await posthog.shutdown() at the end to flush and send all pending events.

https://posthog.com/docs/libraries/node
